### PR TITLE
Release v0.1.13: Fix nil safety in template configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13] - 2025-06-14
+
+### Fixed
+- Nil safety in template configuration: providing only `css` without `header` or `footer` no longer raises `NoMethodError` on nil
+
 ## [0.1.12] - 2025-06-14
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-pandoc-exports (0.1.12)
+    jekyll-pandoc-exports (0.1.13)
       jekyll (>= 3.0)
       pandoc-ruby (~> 2.1)
 

--- a/lib/jekyll-pandoc-exports/generator.rb
+++ b/lib/jekyll-pandoc-exports/generator.rb
@@ -183,23 +183,26 @@ module Jekyll
     end
     
     def self.apply_template(html_content, config)
-      template = config['template']
-      return html_content if template['header'].empty? && template['footer'].empty? && template['css'].empty?
+      template = config['template'] || {}
+      header = template['header'].to_s
+      footer = template['footer'].to_s
+      css = template['css'].to_s
+      return html_content if header.empty? && footer.empty? && css.empty?
       
       # Add custom CSS
-      if !template['css'].empty?
-        css_tag = "<style>#{template['css']}</style>"
+      unless css.empty?
+        css_tag = "<style>#{css}</style>"
         html_content = html_content.sub(/<\/head>/, "#{css_tag}\n</head>")
       end
       
       # Add header after body tag
-      if !template['header'].empty?
-        html_content = html_content.sub(/<body[^>]*>/, "\&\n#{template['header']}")
+      unless header.empty?
+        html_content = html_content.sub(/<body[^>]*>/, "\&\n#{header}")
       end
       
       # Add footer before closing body tag
-      if !template['footer'].empty?
-        html_content = html_content.sub(/<\/body>/, "#{template['footer']}\n</body>")
+      unless footer.empty?
+        html_content = html_content.sub(/<\/body>/, "#{footer}\n</body>")
       end
       
       html_content

--- a/lib/jekyll-pandoc-exports/version.rb
+++ b/lib/jekyll-pandoc-exports/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module PandocExports
-    VERSION = '0.1.12'
+    VERSION = '0.1.13'
   end
 end


### PR DESCRIPTION
## Fixed
- Nil safety in template configuration: providing only `css` without `header` or `footer` no longer raises `NoMethodError` on nil

When users provide only `template.css` in `_config.yml`, the shallow hash merge leaves `header` and `footer` as nil. Calling `.empty?` on nil raises `NoMethodError`. Fix uses `.to_s` to coerce nil to empty string.