### PR TITLE
Release v0.1.14: title_cleanup for both formats with multiline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14] - 2025-06-14
+
+### Fixed
+- `title_cleanup` patterns now apply to both PDF and DOCX exports (previously PDF only)
+- `title_cleanup` patterns now use multiline mode so `.*?` matches across newlines in multi-line HTML elements
+
 ## [0.1.13] - 2025-06-14
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-pandoc-exports (0.1.13)
+    jekyll-pandoc-exports (0.1.14)
       jekyll (>= 3.0)
       pandoc-ruby (~> 2.1)
 

--- a/lib/jekyll-pandoc-exports/generator.rb
+++ b/lib/jekyll-pandoc-exports/generator.rb
@@ -174,6 +174,11 @@ module Jekyll
       # Apply template customizations
       processed = apply_template(processed, config)
       
+      # Apply HTML cleanup patterns (removes unwanted elements before conversion)
+      (config['title_cleanup'] || []).each do |pattern|
+        processed.gsub!(Regexp.new(pattern, Regexp::MULTILINE), '')
+      end
+      
       # Apply image path fixes from config
       config['image_path_fixes'].each do |fix|
         processed.gsub!(Regexp.new(fix['pattern']), fix['replacement'].gsub('{{site.dest}}', site.dest))
@@ -250,9 +255,7 @@ module Jekyll
         end
         
         # Apply title cleanup patterns from config
-        config['title_cleanup'].each do |pattern|
-          pdf_html.gsub!(Regexp.new(pattern), '')
-        end
+        # (Note: also applied in process_html_content for both formats)
         
         # Get PDF options from config or page front matter
         pdf_options = page.data['pdf_options'] || config['pdf_options']

--- a/lib/jekyll-pandoc-exports/version.rb
+++ b/lib/jekyll-pandoc-exports/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module PandocExports
-    VERSION = '0.1.13'
+    VERSION = '0.1.14'
   end
 end


### PR DESCRIPTION
## Fixed
- `title_cleanup` patterns now apply to both PDF and DOCX exports (previously PDF only)
- `title_cleanup` patterns now use multiline mode so `.*?` matches across newlines in multi-line HTML elements
- Guard against nil `title_cleanup` config